### PR TITLE
Fix "validation_status," typo in schema

### DIFF
--- a/tap_chargebee/schemas/customers.json
+++ b/tap_chargebee/schemas/customers.json
@@ -228,7 +228,7 @@
         "zip": {
           "type": ["null", "string"]
         },
-        "validation_status,": {
+        "validation_status": {
           "type": ["null", "string"]
         }
       }

--- a/tap_chargebee/schemas/events.json
+++ b/tap_chargebee/schemas/events.json
@@ -739,7 +739,7 @@
                 "zip": {
                   "type": ["null", "string"]
                 },
-                "validation_status,": {
+                "validation_status": {
                   "type": ["null", "string"]
                 }
               }
@@ -1436,7 +1436,7 @@
                 "zip": {
                   "type": ["null", "string"]
                 },
-                "validation_status,": {
+                "validation_status": {
                   "type": ["null", "string"]
                 }
               }
@@ -1760,7 +1760,7 @@
                   "zip": {
                     "type": ["null", "string"]
                   },
-                  "validation_status,": {
+                  "validation_status": {
                     "type": ["null", "string"]
                   }
                 }
@@ -2514,7 +2514,7 @@
                 "zip": {
                   "type": ["null", "string"]
                 },
-                "validation_status,": {
+                "validation_status": {
                   "type": ["null", "string"]
                 }
               }
@@ -3229,7 +3229,7 @@
                 "zip": {
                   "type": ["null", "string"]
                 },
-                "validation_status,": {
+                "validation_status": {
                   "type": ["null", "string"]
                 },
                 "object": {

--- a/tap_chargebee/schemas/invoices.json
+++ b/tap_chargebee/schemas/invoices.json
@@ -501,7 +501,7 @@
         "zip": {
           "type": ["null", "string"]
         },
-        "validation_status,": {
+        "validation_status": {
           "type": ["null", "string"]
         }
       }

--- a/tap_chargebee/schemas/orders.json
+++ b/tap_chargebee/schemas/orders.json
@@ -250,7 +250,7 @@
 	        "zip": {
 	          "type": ["null", "string"]
 	        },
-	        "validation_status,": {
+	        "validation_status": {
 	          "type": ["null", "string"]
 	        }
 	      }

--- a/tap_chargebee/schemas/subscriptions.json
+++ b/tap_chargebee/schemas/subscriptions.json
@@ -361,7 +361,7 @@
         "zip": {
           "type": ["null", "string"]
         },
-        "validation_status,": {
+        "validation_status": {
           "type": ["null", "string"]
         }
       }


### PR DESCRIPTION
Fixes error:

```
Invalid field name "validation_status,". Fields must contain the allowed characters, and be at most 300 characters long. For allowed characters, please refer to 
```