### PR TITLE
Updating Error Msg Text for prive_variant API

### DIFF
--- a/tap_chargebee/client.py
+++ b/tap_chargebee/client.py
@@ -76,7 +76,7 @@ class ChargebeeClient(BaseClient):
             raise Server429Error()
 
         if response.status_code >= 400:
-            if "This API operation is not enabled" in response.text and "/price_variants" in url:
+            if "configuration_incompatible" in response.text and "/price_variants" in url:
                 LOGGER.warn(f"{response.request.url}: {response.text}")
             else:
                 LOGGER.error("Making {} request to {} with the following params {} got error {}".format(method, url, params, response.text))


### PR DESCRIPTION
# Description of change
Chargebee changed the Error message for the PC1/PC2 compatibility issue. Since Chargebee only changes the error_message, not api_error_code, In this PR, I have modified prive_variant if condition to check the api_error_code text instead of the error msg text.
