### PR TITLE
Add support for deprecated items in Chargebee streams

### DIFF
--- a/tap_chargebee/__init__.py
+++ b/tap_chargebee/__init__.py
@@ -16,6 +16,7 @@ def main():
         required_config_keys=['api_key', 'start_date'])
 
     full_site = args.config.get('full_site', None)
+    args.config['include_deprecated'] = args.config.get('include_deprecated', False)
     
     product_catalog = args.config.get('product_catalog', '1.0')
 

--- a/tap_chargebee/schemas/subscriptions.json
+++ b/tap_chargebee/schemas/subscriptions.json
@@ -5,6 +5,9 @@
     "id": {
       "type": ["null", "string"]
     },
+    "active_id": {
+      "type": ["null", "string"]
+    },
     "customer_id": {
       "type": ["null", "string"]
     },

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -208,6 +208,9 @@ class BaseChargebeeStream(BaseStream):
             for field_name, field_value in entity_filters.items():
                 params[field_name] = field_value
                 LOGGER.info("Querying filtering by {}={}".format(field_name, field_value))
+        
+        if self.config.get('include_deprecated') is True and self.TABLE in ['customers', 'subscriptions']:
+            params["include_deprecated"] = "true"
                 
         ids = set()
         while not done:

--- a/tap_chargebee/streams/customers.py
+++ b/tap_chargebee/streams/customers.py
@@ -15,3 +15,9 @@ class CustomersStream(BaseChargebeeStream):
 
     def get_url(self):
         return 'https://{}/api/v2/customers'.format(self.config.get('full_site'))
+
+    def get_params(self, params):
+        params = super().get_params(params)
+        if self.config.get('include_deprecated') is True:
+            params["include_deprecated"] = "true"
+        return params

--- a/tap_chargebee/streams/customers.py
+++ b/tap_chargebee/streams/customers.py
@@ -15,9 +15,3 @@ class CustomersStream(BaseChargebeeStream):
 
     def get_url(self):
         return 'https://{}/api/v2/customers'.format(self.config.get('full_site'))
-
-    def get_params(self, params):
-        params = super().get_params(params)
-        if self.config.get('include_deprecated') is True:
-            params["include_deprecated"] = "true"
-        return params

--- a/tap_chargebee/streams/subscriptions.py
+++ b/tap_chargebee/streams/subscriptions.py
@@ -15,9 +15,3 @@ class SubscriptionsStream(BaseChargebeeStream):
 
     def get_url(self):
         return 'https://{}/api/v2/subscriptions'.format(self.config.get('full_site'))
-
-    def get_params(self, params):
-        params = super().get_params(params)
-        if self.config.get('include_deprecated') is True:
-            params["include_deprecated"] = "true"
-        return params

--- a/tap_chargebee/streams/subscriptions.py
+++ b/tap_chargebee/streams/subscriptions.py
@@ -15,3 +15,9 @@ class SubscriptionsStream(BaseChargebeeStream):
 
     def get_url(self):
         return 'https://{}/api/v2/subscriptions'.format(self.config.get('full_site'))
+
+    def get_params(self, params):
+        params = super().get_params(params)
+        if self.config.get('include_deprecated') is True:
+            params["include_deprecated"] = "true"
+        return params


### PR DESCRIPTION
- Introduced 'include_deprecated' configuration option in the main function to control the inclusion of deprecated items.
- Added 'active_id' field to the subscriptions schema for better tracking of active subscriptions.
- Updated CustomersStream and SubscriptionsStream to include 'include_deprecated' parameter in API requests when enabled.