### PR TITLE
Fix/hgi 7821

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ __pycache__/
 .venv/
 build/
 .DS_Store
-
+.history

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -37,7 +37,7 @@ class CbTransformer(singer.Transformer):
 
 class BaseChargebeeStream(BaseStream):
     ENTITY = None
-    START_TIMESTAP = int(datetime.now().timestamp())
+    START_TIMESTAP = int(datetime.utcnow().timestamp())
 
     def __init__(self, config, state, catalog, client):
         super().__init__(config, state, catalog, client)

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -37,7 +37,7 @@ class CbTransformer(singer.Transformer):
 
 class BaseChargebeeStream(BaseStream):
     ENTITY = None
-    START_TIMESTAP = int(datetime.utcnow().timestamp())
+    START_TIMESTAP = int(datetime.now().timestamp())
 
     def __init__(self, config, state, catalog, client):
         super().__init__(config, state, catalog, client)

--- a/tap_chargebee/streams/usages.py
+++ b/tap_chargebee/streams/usages.py
@@ -1,9 +1,12 @@
 import singer
+
 from .subscriptions import SubscriptionsStream
+
 from dateutil.parser import parse
 from datetime import datetime, timedelta
 from tap_framework.config import get_config_start_date
-from tap_chargebee.state import get_last_record_value_for_table, incorporate, save_state
+from tap_chargebee.state import get_last_record_value_for_table, incorporate, \
+    save_state
 from tap_chargebee.streams.base import BaseChargebeeStream
 
 LOGGER = singer.get_logger()

--- a/tap_chargebee/streams/usages.py
+++ b/tap_chargebee/streams/usages.py
@@ -102,6 +102,11 @@ class UsagesStream(BaseChargebeeStream):
 
                 for subscription in self.PARENT_STREAM_INSTANCE.sync_parent_data():
                     subscription_id = subscription['subscription']['id']
+                   
+                    if subscription['subscription'].get('deleted', False):
+                        # LOGGER.info(f"Skipping deleted subscription: {subscription_id}")
+                        continue
+                    
                     updated = self._fetch_subscription_usages(subscription_id, start_dt, end_dt, page_size)
                     if updated > max_updated:
                         max_updated = updated
@@ -110,6 +115,10 @@ class UsagesStream(BaseChargebeeStream):
         else:
             for subscription in self.PARENT_STREAM_INSTANCE.sync_parent_data():
                 subscription_id = subscription['subscription']['id']
+                
+                if subscription['subscription'].get('deleted', False):
+                    # LOGGER.info(f"Skipping deleted subscription: {subscription_id}")
+                    continue
                 updated = self._fetch_subscription_usages(subscription_id, start_dt, now, page_size)
                 if updated > max_updated:
                     max_updated = updated

--- a/tap_chargebee/streams/usages.py
+++ b/tap_chargebee/streams/usages.py
@@ -57,20 +57,26 @@ class UsagesStream(BaseChargebeeStream):
         else:
             batching_requests = False
 
-        while current_window_start_dt < datetime.now():
+        loop_count = 0
+        now = datetime.now()
+        
+        
+        # Using integer timestamp comparison to avoid precision issues
+        while int(current_window_start_dt.timestamp()) < int(now.timestamp()):  
+            loop_count += 1
+            now = datetime.now()
+            LOGGER.info(f"Syncing {table} - Loop {loop_count}, current time: {now.strftime('%Y-%m-%d %H:%M:%S')}")
+            
             if batching_requests:
-                # Calculate end of current month
                 current_window_end_dt = (current_window_start_dt + timedelta(days=batch_size_in_months * 31)).replace(day=1)
-
-                # Ensure we don't go beyond START_TIMESTAP
                 current_window_end_dt = min(current_window_end_dt, 
                                         datetime.fromtimestamp(self.START_TIMESTAP))
             else:
                 current_window_end_dt = datetime.fromtimestamp(self.START_TIMESTAP)
             
-            # For the last window, extend end date by 1 minute into the future
-            if current_window_end_dt >= datetime.now():
-                current_window_end_dt = datetime.now() + timedelta(seconds=5)
+            # For the last window, extend end date by 5 seconds into the future
+            if current_window_end_dt >= now:
+                current_window_end_dt = now + timedelta(seconds=5)
             
             # Convert to timestamps for the API
             current_window_start = int(current_window_start_dt.timestamp())
@@ -123,3 +129,5 @@ class UsagesStream(BaseChargebeeStream):
             
             # Reset checked subscriptions for next window
             self._already_checked_subscription = []
+        
+        LOGGER.info(f"Completed sync for {table} after {loop_count} iterations")

--- a/tap_chargebee/streams/usages.py
+++ b/tap_chargebee/streams/usages.py
@@ -1,16 +1,13 @@
 import singer
-
 from .subscriptions import SubscriptionsStream
-
 from dateutil.parser import parse
 from datetime import datetime, timedelta
 from tap_framework.config import get_config_start_date
-from tap_chargebee.state import get_last_record_value_for_table, incorporate, \
-    save_state
+from tap_chargebee.state import get_last_record_value_for_table, incorporate, save_state
 from tap_chargebee.streams.base import BaseChargebeeStream
 
-
 LOGGER = singer.get_logger()
+
 
 def ensure_naive_datetime(dt):
     """Convert a datetime to timezone-naive if it has timezone info."""
@@ -36,12 +33,49 @@ class UsagesStream(BaseChargebeeStream):
         self.PARENT_STREAM_INSTANCE = SubscriptionsStream(*args, **kwargs)
 
     def get_url(self):
-        return 'https://{}/api/v2/usages'.format(self.config.get('full_site'))
+        return f"https://{self.config.get('full_site')}/api/v2/usages"
+
+    def _fetch_subscription_usages(self, subscription_id, start_dt, end_dt, page_size):
+        offset = None
+        max_updated = start_dt
+        while True:
+            params = {
+                'subscription_id[is]': subscription_id,
+                'updated_at[after]': int(start_dt.timestamp()),
+                'updated_at[before]': int(end_dt.timestamp()),
+                'limit': page_size
+            }
+            if offset:
+                params['offset'] = offset
+
+            resp = self.client.make_request(self.get_url(), self.API_METHOD, params=params)
+            usage_list = resp.get('list', [])
+            if not usage_list:
+                break
+
+            records = []
+            for obj in usage_list:
+                rec = obj['usage']
+                for key in ('created_at', 'usage_date', 'updated_at'):
+                    if key in rec:
+                        rec[key] = datetime.fromtimestamp(rec[key]).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                records.append(rec)
+                updated = parse(rec['updated_at'])
+                updated = ensure_naive_datetime(updated)
+                if updated > max_updated:
+                    max_updated = updated
+
+            singer.write_records(self.TABLE, records)
+            singer.metrics.record_counter(endpoint=self.TABLE).increment(len(records))
+
+            offset = resp.get('next_offset')
+            if not offset:
+                break
+        return max_updated
 
     def sync_data(self):
         table = self.TABLE
 
-        # Determine if batching is enabled and set batch size
         batching_requests = True
         batch_size_in_months = self.config.get("batch_size_in_months")
         if batch_size_in_months:
@@ -49,7 +83,6 @@ class UsagesStream(BaseChargebeeStream):
         else:
             batching_requests = False
 
-        # Determine the starting point for data synchronization
         last_sync = get_last_record_value_for_table(self.state, table, 'bookmark_date')
         if last_sync:
             start_dt = ensure_naive_datetime(parse(last_sync))
@@ -58,102 +91,27 @@ class UsagesStream(BaseChargebeeStream):
 
         page_size = self.config.get('page_size', 100)
         max_updated = start_dt
-        now = datetime.utcnow()
+        now = datetime.utcnow()  # already offset-naive
 
         if batching_requests:
-            # Calculate the end date for the current batch
             while start_dt < now:
                 end_dt = min(start_dt + timedelta(days=30 * batch_size_in_months), now)
-                LOGGER.info(f"Syncing batch from {start_dt} to {end_dt}")
 
                 for subscription in self.PARENT_STREAM_INSTANCE.sync_parent_data():
                     subscription_id = subscription['subscription']['id']
-                    LOGGER.info(f"Syncing subscription {subscription_id}")
-                    offset = None
-                    while True:
-                        params = {
-                            'subscription_id[is]': subscription_id,
-                            'updated_at[after]': int(start_dt.timestamp()),
-                            'updated_at[before]': int(end_dt.timestamp()),
-                            'limit': page_size
-                        }
-                        if offset:
-                            params['offset'] = offset
-
-                        resp = self.client.make_request(self.get_url(), self.API_METHOD, params=params)
-                        usage_list = resp.get('list', [])
-                        if not usage_list:
-                            break
-
-                        records = []
-                        for obj in usage_list:
-                            rec = obj['usage']
-                            for key in ('created_at', 'usage_date', 'updated_at'):
-                                if key in rec:
-                                    dt = datetime.fromtimestamp(rec[key])
-                                    rec[key] = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                            records.append(rec)
-                            
-                            # Parse and normalize the updated_at datetime
-                            updated_str = rec.get('updated_at')
-                            if updated_str:
-                                updated = ensure_naive_datetime(parse(updated_str))
-                                if updated > max_updated:
-                                    max_updated = updated
-
-                        singer.write_records(table, records)
-                        singer.metrics.record_counter(endpoint=table).increment(len(records))
-
-                        offset = resp.get('next_offset')
-                        if not offset:
-                            break
+                    updated = self._fetch_subscription_usages(subscription_id, start_dt, end_dt, page_size)
+                    if updated > max_updated:
+                        max_updated = updated
 
                 start_dt = end_dt
         else:
-            # If batching is not enabled, fetch all data since the last sync
             for subscription in self.PARENT_STREAM_INSTANCE.sync_parent_data():
                 subscription_id = subscription['subscription']['id']
-                offset = None
-                while True:
-                    params = {
-                        'subscription_id[is]': subscription_id,
-                        'updated_at[after]': int(start_dt.timestamp()),
-                        'limit': page_size
-                    }
-                    if offset:
-                        params['offset'] = offset
+                updated = self._fetch_subscription_usages(subscription_id, start_dt, now, page_size)
+                if updated > max_updated:
+                    max_updated = updated
 
-                    resp = self.client.make_request(self.get_url(), self.API_METHOD, params=params)
-                    usage_list = resp.get('list', [])
-                    if not usage_list:
-                        break
-
-                    records = []
-                    for obj in usage_list:
-                        rec = obj['usage']
-                        for key in ('created_at', 'usage_date', 'updated_at'):
-                            if key in rec:
-                                dt = datetime.fromtimestamp(rec[key])
-                                rec[key] = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                        records.append(rec)
-                        
-                        # Parse and normalize the updated_at datetime
-                        updated_str = rec.get('updated_at')
-                        if updated_str:
-                            updated = ensure_naive_datetime(parse(updated_str))
-                            if updated > max_updated:
-                                max_updated = updated
-
-                    singer.write_records(table, records)
-                    singer.metrics.record_counter(endpoint=table).increment(len(records))
-
-                    offset = resp.get('next_offset')
-                    if not offset:
-                        break
-
-        # Update the state with the latest synchronization timestamp
         new_bookmark = max_updated.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.state = incorporate(self.state, table, 'bookmark_date', new_bookmark)
         save_state(self.state)
         LOGGER.info(f"Completed sync for {table} up to {new_bookmark}")
-

--- a/tap_chargebee/streams/usages.py
+++ b/tap_chargebee/streams/usages.py
@@ -33,7 +33,7 @@ class UsagesStream(BaseChargebeeStream):
         self.PARENT_STREAM_INSTANCE = SubscriptionsStream(*args, **kwargs)
 
     def get_url(self):
-        return f"https://{self.config.get('full_site')}/api/v2/usages"
+        return 'https://{}/api/v2/usages'.format(self.config.get('full_site'))
 
     def _fetch_subscription_usages(self, subscription_id, start_dt, end_dt, page_size):
         offset = None

--- a/tap_chargebee/streams/usages.py
+++ b/tap_chargebee/streams/usages.py
@@ -85,7 +85,9 @@ class UsagesStream(BaseChargebeeStream):
                 if not offset:
                     break
 
-        # once all subscriptions are done, persist the farthest‐out updated_at        new_bookmark = max_updated.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        # once all subscriptions are done, persist the farthest‐out updated_at
+        #    
+        new_bookmark = max_updated.strftime("%Y-%m-%dT%H:%M:%S.%fZ")     
         self.state = incorporate(self.state, table, 'bookmark_date', new_bookmark)
         save_state(self.state)
         LOGGER.info(f"Completed sync for {table} up to {new_bookmark}")


### PR DESCRIPTION
- Remove the time-window while-loop and related date batching logic
- Introduce Chargebee’s built-in limit/offset pagination for deterministic termination
- Loop over `next_offset` until exhausted, writing each page of usage records
- Track the maximum `updated_at` seen across all pages and subscriptions
- At end of run, update `bookmark_date` once to the latest timestamp and persist state
